### PR TITLE
Alt err

### DIFF
--- a/src/combinators/alt.rs
+++ b/src/combinators/alt.rs
@@ -22,11 +22,11 @@ impl<I,O,P> Alt<I,O,P> {
 }
 
 macro_rules! alt_parser_impl {
-  ($TG:ident, $($MG:ident),+) => {
-    impl<IN:Clone, $TG, $($MG),+> From<($($MG),+)> for Alt<IN,$TG,($($MG,)+)> 
-    where $($MG:Parser<IN,$TG>,)+
+  ($TYPE:ident; $($PARSER:ident),+) => {
+    impl<IN:Clone, $TYPE, $($PARSER),+> From<($($PARSER),+)> for Alt<IN,$TYPE,($($PARSER,)+)> 
+    where $($PARSER:Parser<IN,$TYPE>,)+
     {
-      fn from(ps:($($MG),+)) -> Self {
+      fn from(ps:($($PARSER),+)) -> Self {
         Self {
           ps,
           _ghost:std::marker::PhantomData
@@ -35,33 +35,41 @@ macro_rules! alt_parser_impl {
     }
 
     #[allow(non_snake_case)] //you are gonna re-use generic names as variable names
-    impl<IN:Clone, $TG, $($MG),+ > Parser<IN,$TG> for Alt<IN,$TG,($($MG,)+)>
-    where $($MG:Parser<IN,$TG>,)+
+    impl<IN:Clone, $TYPE, $($PARSER),+ > Parser<IN,$TYPE> for Alt<IN,$TYPE,($($PARSER,)+)>
+    where $($PARSER:Parser<IN,$TYPE>,)+
     {
-      type Error=AltErr<IN>;
+      type Error=($($PARSER::Error),+);
 
-      fn parse(&self,txt:IN)->Result<($TG,IN),AltErr<IN>> {
-        let Alt{ ps:($($MG),+),.. } = self;
+      fn parse(&self,txt:IN)->Result<($TYPE,IN),Self::Error> {
+        let Alt{ ps:($($PARSER),+),.. } = self;
 
-        $( if let Ok((v,r)) = $MG.parse(txt.clone()) { return Ok((v,r)); })+
-        Err(txt.into())
+        //this works cause let A = match A will get the variables right
+        $( let $PARSER = match $PARSER.parse(txt.clone()) { 
+          Ok((v,r)) => return Ok((v,r)),
+          Err(e) => e
+        };)+
+
+        Err(($($PARSER),+))
       }
     }
   }
 }
 
-alt_parser_impl!(Typ, A,B);
-alt_parser_impl!(Typ, A,B,C);
-alt_parser_impl!(Typ, A,B,C,D);
-alt_parser_impl!(Typ, A,B,C,D,E);
-alt_parser_impl!(Typ, A,B,C,D,E,F);
-alt_parser_impl!(Typ, A,B,C,D,E,F,G);
-alt_parser_impl!(Typ, A,B,C,D,E,F,G,H);
-alt_parser_impl!(Typ, A,B,C,D,E,F,G,H,I);
-alt_parser_impl!(Typ, A,B,C,D,E,F,G,H,I,J);
-alt_parser_impl!(Typ, A,B,C,D,E,F,G,H,I,J,K);
-alt_parser_impl!(Typ, A,B,C,D,E,F,G,H,I,J,K,L);
-alt_parser_impl!(Typ, A,B,C,D,E,F,G,H,I,J,K,L,M);
+
+//we could do some macro recursion to get rid of these pyramids
+//but I think this makes the macro itself easier to read
+alt_parser_impl!(Typ; A,B);
+alt_parser_impl!(Typ; A,B,C);
+alt_parser_impl!(Typ; A,B,C,D);
+alt_parser_impl!(Typ; A,B,C,D,E);
+alt_parser_impl!(Typ; A,B,C,D,E,F);
+alt_parser_impl!(Typ; A,B,C,D,E,F,G);
+alt_parser_impl!(Typ; A,B,C,D,E,F,G,H);
+alt_parser_impl!(Typ; A,B,C,D,E,F,G,H,I);
+alt_parser_impl!(Typ; A,B,C,D,E,F,G,H,I,J);
+alt_parser_impl!(Typ; A,B,C,D,E,F,G,H,I,J,K);
+alt_parser_impl!(Typ; A,B,C,D,E,F,G,H,I,J,K,L);
+alt_parser_impl!(Typ; A,B,C,D,E,F,G,H,I,J,K,L,M);
 
 //this is a convenience method to make constructing an alt easier
 // the into trait ends up just being kinda helpful as it's safer to
@@ -75,30 +83,30 @@ mod tests {
   use super::*;
 
   //some parsers
-  fn dog(inp:&str) -> Result<(&str,&str),()> {
+  fn dog(inp:&str) -> Result<(&str,&str),&'static str> {
     match &inp[0..3] {
       "dog" => Ok((&inp[0..3],&inp[3..])),
-      _ => Err(())  
+      _ => Err("oh no")  
     }
   }
 
-  fn cat(inp:&str) -> Result<(&str,&str),()> {
+  fn cat(inp:&str) -> Result<(&str,&str),usize> {
     match &inp[0..3] {
       "cat" => Ok((&inp[0..3],&inp[3..])),
-      _ => Err(())
+      _ => Err(15)
     }
   }
 
-  fn fish(inp:&str) -> Result<(&str,&str),()> {
+  fn fish(inp:&str) -> Result<(&str,&str),bool> {
     match &inp[0..4] {
       "fish" => Ok((&inp[0..4],&inp[4..])),
-      _ => Err(())
+      _ => Err(false)
     }
   }
 
   #[test]
   fn test_alts() {
-    let z = alt((dog,cat,fish)).map_err(|_|());
+    let z = alt((dog,cat,fish));
 
     let (out,res) = z.parse("dogzone").expect("the dog parser should succeed");
     assert_eq!("dog",out);
@@ -112,7 +120,8 @@ mod tests {
     assert_eq!("cat",out);
     assert_eq!("seldorf",res);
 
-    let bad = z.parse("if you can't hang with the big dog, get off the porch");
-    assert!(bad.is_err());
+    let bad = z.parse("if you can't hang with the big dog, get off the porch")
+    .expect_err("this should error all over the place");
+    assert!(matches!(bad,("oh no",15,false)));
   }
 }

--- a/src/combinators/alt.rs
+++ b/src/combinators/alt.rs
@@ -1,5 +1,4 @@
 use crate::parser::Parser;
-use crate::err::AltErr;
 //this is a vehicle to implement the parser trait
 //I'm already using tuples to handle sequential
 //parsing.
@@ -54,7 +53,6 @@ macro_rules! alt_parser_impl {
     }
   }
 }
-
 
 //we could do some macro recursion to get rid of these pyramids
 //but I think this makes the macro itself easier to read

--- a/src/combinators/sequential.rs
+++ b/src/combinators/sequential.rs
@@ -1,4 +1,5 @@
 use crate::parser::Parser;
+
 /*=============================================================================
 This macro implemnts the parser trait for tuples of parsers, and makes them run in sequence,
 so for example if you have the parser "word" which matches a bunch of letters
@@ -85,4 +86,5 @@ mod tests
     let bad = morse_sos.parse("...---...");
     assert!(bad.is_err());
   }
+
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 mod parser;
 mod combinators;
-mod err;
 
 pub use parser::Parser;
 pub use combinators::{
@@ -8,8 +7,4 @@ pub use combinators::{
   sequential, //this ones funny cause it just pulls in an impl
   iter,
   basics
-};
-
-pub use err::{
-  AltErr
 };


### PR DESCRIPTION
Changes the alt combinator to return all the different errors it got.
This is a double edged sword, if you are parsing simple things it's fine, if you have complicated
things you can quickly get to a crazy error that you have to box up or somethign